### PR TITLE
Replace blacklist with denylist and use Larastan Org

### DIFF
--- a/src/Support/BlackList.php
+++ b/src/Support/BlackList.php
@@ -20,7 +20,7 @@ class BlackList
         'Google\Cloud\Core\Logger\AppEngineFlexHandler',
         'Google\Cloud\Core\Testing\GcTestListener',
         'League\Flysystem\Cached\Storage\Noop',
-        'NunoMaduro\Larastan\ApplicationResolver',
+        'Larastan\Larastan\ApplicationResolver',
         'Psy\Readline\Hoa\FileLink',
         'Psy\Readline\Hoa\FileFinder',
         'Psy\Readline\Hoa\FileLinkRead',

--- a/src/Support/BlackList.php
+++ b/src/Support/BlackList.php
@@ -5,7 +5,7 @@ namespace Spatie\PhpTypeGraph\Support;
 /**
  * A list of classes which are incomplete and throw uncatchable errors
  */
-class BlackList
+class DenyList
 {
     public static array $entries = [
         'Algolia\AlgoliaSearch\Cache\FileCacheDriver',

--- a/src/Support/ReferenceChecker.php
+++ b/src/Support/ReferenceChecker.php
@@ -10,7 +10,7 @@ class ReferenceChecker
 
     public static function exists(string $class): bool
     {
-        if (in_array($class, BlackList::$entries)) {
+        if (in_array($class, DenyList::$entries)) {
             return false;
         }
 


### PR DESCRIPTION
Updates blacklist to denylist from one of the alternatives recommended (sample: https://github.com/ietf/terminology#alternative-terminology). The purpose is to use more inclusive and non-biased language. The changes align with industry-wide movement for inclusive terminology.

Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization. 